### PR TITLE
feat: SRE実績を最新化（Lambda@Edge認証・drift検知・tfstate層分離）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+- **SRE実績を最新化（Lambda@Edge認証・drift検知・tfstate層分離）**
+  - 自己PR: SRE基盤構築実績ハイライトにinfra/app層分離・Lambda@Edge Cognito認証・週次drift検知を追記
+  - プロジェクト: daihou-sre の成果にLambda@Edge Cognito認証基盤（SecretsManager統合）・OIDC IAMロール保護設計を追記
+  - プロジェクト: daihou-sre の技術タグに Lambda@Edge / Cognito / SecretsManager を追加
+  - 学習・今後: DOP目標を「2026年夏」に具体化・SAP-C02を新規追加・SRE深化の内容を更新
+
 ### Added
 - **SRE実績・スキルセクション最新化（#8）**
   - 自己PR: だいほう合同会社創業（2025年7月）・SRE基盤構築実績ハイライト追加

--- a/index.html
+++ b/index.html
@@ -636,8 +636,9 @@
 
                     <div class="pr-highlight">
                         <strong>🛠️ SRE基盤構築実績:</strong><br>
-                        Terraform IaC（tfstate層分離・drift検知CI・OIDC認証）・CloudWatch Alarm 27本のコード管理化・
-                        SLI/SLO定義・ECS Fargate Runbook整備・Security Hub有効化まで、SRE基盤を一から構築。
+                        Terraform IaC（infra/app層分離・週次drift検知自動起票・OIDC IAMロール保護）・
+                        Lambda@Edge + Cognito認証基盤（SecretsManager統合）・CloudWatch Alarm 27本・
+                        SLI/SLO定義・ECS Fargate Runbook 4本・Security Hub有効化まで、SRE基盤を一から設計・構築・継続運用中。
                     </div>
 
                     <p>
@@ -772,13 +773,16 @@
                             <span>🎯 SRE/IaC</span>
                         </div>
                         <div class="project-description">
-                            <strong>概要：</strong>だいほう合同会社のSRE基盤をゼロから設計・構築・運用<br>
-                            <strong>成果：</strong>Terraform IaC化（tfstate層分離・drift検知CI）・CloudWatch Alarm 27本のコード管理化・SLI/SLO定義・ECS Fargate Runbook 4本整備・Security Hub有効化<br>
-                            <strong>役割：</strong>SRE全体設計・Terraform実装・CI/CD整備・ドキュメント化を単独担当
+                            <strong>概要：</strong>だいほう合同会社のSRE基盤をゼロから設計・構築・継続運用<br>
+                            <strong>成果：</strong>Terraform IaC化（infra/app層分離・週次drift検知Issue自動起票・OIDC IAMロール保護設計）・Lambda@Edge Cognito認証基盤構築（SecretsManager統合）・CloudWatch Alarm 27本・SLI/SLO定義・ECS Fargate Runbook 4本・Security Hub有効化<br>
+                            <strong>役割：</strong>SRE全体設計・Terraform実装・セキュリティ設計・CI/CD整備を単独担当
                         </div>
                         <div class="tech-tags">
                             <span class="tech-tag">Terraform</span>
                             <span class="tech-tag">ECS Fargate</span>
+                            <span class="tech-tag">Lambda@Edge</span>
+                            <span class="tech-tag">Cognito</span>
+                            <span class="tech-tag">SecretsManager</span>
                             <span class="tech-tag">GitHub Actions</span>
                             <span class="tech-tag">CloudWatch</span>
                             <span class="tech-tag">Security Hub</span>
@@ -920,15 +924,15 @@
                 <div class="learning-grid">
                     <div class="learning-item">
                         <h3>🏆 DOP-C02取得</h3>
-                        <p>AWS DevOps Engineer Professional<br>2026年取得目標</p>
+                        <p>AWS DevOps Engineer Professional<br>2026年夏 取得目標</p>
+                    </div>
+                    <div class="learning-item">
+                        <h3>🏆 SAP-C02取得</h3>
+                        <p>AWS Solutions Architect Professional<br>DOP取得後・2026年末 目標</p>
                     </div>
                     <div class="learning-item">
                         <h3>🛠️ SRE深化</h3>
-                        <p>Observability強化<br>カオスエンジニアリング</p>
-                    </div>
-                    <div class="learning-item">
-                        <h3>🐍 Python(boto3)</h3>
-                        <p>AWS運用自動化スクリプト<br>データパイプライン構築</p>
+                        <p>カオスエンジニアリング実践<br>Observability・Terraform設計高度化</p>
                     </div>
                     <div class="learning-item">
                         <h3>🤖 AI活用拡大</h3>


### PR DESCRIPTION
## Summary

- 自己PR: Lambda@Edge + Cognito認証基盤・週次drift検知自動起票・OIDC IAMロール保護を追記
- daihou-sre プロジェクト: 成果文・技術タグを最新実装（SecretsManager統合・infra/app層分離）に更新
- 学習セクション: DOP目標を「2026年夏」に具体化・SAP-C02追加・SRE深化内容更新

## 変更箇所

| セクション | 変更内容 |
|:---|:---|
| 自己PR ハイライトBOX | infra/app層分離・Lambda@Edge Cognito認証・週次drift検知を追記 |
| daihou-sre 成果 | Lambda@Edge認証基盤（SecretsManager統合）・OIDC IAMロール保護設計を追記 |
| daihou-sre タグ | Lambda@Edge / Cognito / SecretsManager を追加 |
| 学習・今後 | DOP「2026年夏」・SAP-C02新規追加・SRE深化内容更新 |

## Test plan

- [ ] GitHub Pages でプレビュー確認（push後1-2分で反映）
- [ ] 自己PRセクションの文言確認
- [ ] daihou-sreプロジェクトカードのタグ表示確認
- [ ] 学習セクションの4項目確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)