### PR TITLE
feat: 直近案件・初期キャリア追加・スキル・学習セクション更新

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- **直近案件・初期キャリア追加・スキル更新（#12）**
+  - プロジェクト: 直近案件（2026/02-05）オンプレプリントサービス基盤更改AWS環境構築（Terraform IaC）を追加
+  - プロジェクト: 初期キャリア（2001/04-2010/04）インフラエンジニア（OS/NW/Firewall）をデータセンター仮想化基盤の前に追加
+  - スキル: セキュリティ・NWにAWSセキュリティ（GuardDuty/Security Hub/WAF/Config/CloudTrail/KMS/SecretsManager）を追加
+  - 学習: SRE深化の「カオスエンジニアリング実践」を削除してシンプル化
+
 ### Changed
 - **SRE実績を最新化（Lambda@Edge認証・drift検知・tfstate層分離）**
   - 自己PR: SRE基盤構築実績ハイライトにinfra/app層分離・Lambda@Edge Cognito認証・週次drift検知を追記

--- a/index.html
+++ b/index.html
@@ -738,6 +738,10 @@
                     <div class="skill-category">
                         <h3>🔒 セキュリティ・NW</h3>
                         <div class="skill-item">
+                            <div class="skill-name">AWSセキュリティ<span class="experience-level new">実務あり</span></div>
+                            <div class="skill-detail">GuardDuty, Security Hub, WAF, Config, CloudTrail, KMS, SecretsManager</div>
+                        </div>
+                        <div class="skill-item">
                             <div class="skill-name">Firewall<span class="experience-level">実務10年</span></div>
                             <div class="skill-detail">Fortigate, SonicWall設計・運用</div>
                         </div>
@@ -814,6 +818,27 @@
                             <span class="tech-tag">Terraform</span>
                             <span class="tech-tag">Python</span>
                             <span class="tech-tag">SLI/SLO</span>
+                        </div>
+                    </div>
+
+                    <div class="project-card">
+                        <h3>オンプレ基盤更改に伴うAWS環境構築（Terraform IaC）</h3>
+                        <div class="project-meta">
+                            <span>📅 2026年2月〜5月</span>
+                            <span>👥 PMO（10名）</span>
+                            <span>🎯 AWS移行・IaC</span>
+                        </div>
+                        <div class="project-description">
+                            <strong>概要：</strong>王手小売りチェーンのオンプレプリントサービス基盤更改に伴うAWS環境の要件定義・設計・構築<br>
+                            <strong>成果：</strong>Terraform + GitでのIaC基盤を整備し、要件定義から構築・試験まで一貫して担当<br>
+                            <strong>役割：</strong>PMO・Terraform実装・CI/CD整備
+                        </div>
+                        <div class="tech-tags">
+                            <span class="tech-tag">Terraform</span>
+                            <span class="tech-tag">Ansible</span>
+                            <span class="tech-tag">Git</span>
+                            <span class="tech-tag">Linux</span>
+                            <span class="tech-tag">CI/CD</span>
                         </div>
                     </div>
 
@@ -897,6 +922,29 @@
                     </div>
 
                     <div class="project-card">
+                        <h3>インフラエンジニア（OS・NW・Firewall 設計〜保守）</h3>
+                        <div class="project-meta">
+                            <span>📅 2001年4月〜2010年4月</span>
+                            <span>👥 メンバー（15名）</span>
+                            <span>🎯 インフラ全般</span>
+                        </div>
+                        <div class="project-description">
+                            <strong>概要：</strong>情報サービス業界でWindows/Linux/Firewallを中心としたインフラ案件の設計・構築・運用・保守を担当<br>
+                            <strong>成果：</strong>L2/L3スイッチ・Firewall・Windows/Linuxサーバ・DBまで幅広い技術領域を習得。10年間で大規模インフラの基盤スキルを確立<br>
+                            <strong>役割：</strong>メンバー（設計・構築・運用・保守）
+                        </div>
+                        <div class="tech-tags">
+                            <span class="tech-tag">RHEL/CentOS</span>
+                            <span class="tech-tag">Windows Server</span>
+                            <span class="tech-tag">Firewall</span>
+                            <span class="tech-tag">L2/L3スイッチ</span>
+                            <span class="tech-tag">SonicWall</span>
+                            <span class="tech-tag">Oracle</span>
+                            <span class="tech-tag">PostgreSQL</span>
+                        </div>
+                    </div>
+
+                    <div class="project-card">
                         <h3>データセンター仮想化基盤（10年間）</h3>
                         <div class="project-meta">
                             <span>📅 2010年5月〜2020年1月</span>
@@ -932,7 +980,7 @@
                     </div>
                     <div class="learning-item">
                         <h3>🛠️ SRE深化</h3>
-                        <p>カオスエンジニアリング実践<br>Observability・Terraform設計高度化</p>
+                        <p>Observability強化<br>Terraform設計高度化</p>
                     </div>
                     <div class="learning-item">
                         <h3>🤖 AI活用拡大</h3>


### PR DESCRIPTION
## Summary

- プロジェクト追加（直近）: 2026/02-05 オンプレプリントサービス基盤更改に伴うAWS環境構築（Terraform IaC・PMO）
- プロジェクト追加（初期）: 2001/04-2010/04 インフラエンジニア（OS/NW/Firewall 設計〜保守）をデータセンター仮想化基盤の前に配置
- スキル: セキュリティ・NWカテゴリにAWSセキュリティサービスを追加（GuardDuty / Security Hub / WAF / Config / CloudTrail / KMS / SecretsManager）
- 学習: SRE深化の「カオスエンジニアリング実践」を削除してシンプル化

## Test plan

- [ ] プロジェクト一覧の順序確認（daihou-sre → CloudLogAI → 2026直近 → オンプレ+AWS → ... → 2001-2010 → データセンター仮想化）
- [ ] セキュリティ・NWセクションのAWSセキュリティ追加確認
- [ ] 学習セクションの表示確認

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)