### PR TITLE
feat: CHANGELOGバージョン検知による自動リリースワークフローを追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Auto Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  auto-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from CHANGELOG
+        id: version
+        run: |
+          VERSION=$(grep -m1 '^## \[[0-9]' CHANGELOG.md | sed 's/## \[\([^]]*\)\].*/\1/')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Found version: $VERSION"
+
+      - name: Check if tag exists
+        id: tag_check
+        run: |
+          if git ls-remote --tags origin "refs/tags/v${{ steps.version.outputs.version }}" | grep -q .; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create tag and release
+        if: steps.tag_check.outputs.exists == 'false' && steps.version.outputs.version != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "v${{ steps.version.outputs.version }}" -m "Release v${{ steps.version.outputs.version }}"
+          git push origin "v${{ steps.version.outputs.version }}"
+          gh release create "v${{ steps.version.outputs.version }}" \
+            --title "v${{ steps.version.outputs.version }}" \
+            --generate-notes \
+            --latest

--- a/docs/adr/ADR-001-changelog-version-release-trigger.md
+++ b/docs/adr/ADR-001-changelog-version-release-trigger.md
@@ -1,0 +1,38 @@
+# ADR-001: CHANGELOG.md バージョン更新 = GitHub Release 自動生成トリガー
+
+## ステータス
+
+承認済み（2026-05-05）
+
+## コンテキスト
+
+GitHub Releases が手動更新のため更新忘れが発生しやすく、タグ管理も統一されていなかった。
+リリース作業を自動化しつつ、リリース粒度は人間がコントロールできる仕組みが必要。
+
+## 決定
+
+CHANGELOG.md の最新バージョンヘッダ（`## [x.y.z]`）を GitHub Release の自動作成トリガーとする。
+
+### リリースフロー
+
+1. 通常の PR はそのまま main にマージ（`## [Unreleased]` のまま → リリースなし）
+2. リリースしたい時は `## [Unreleased]` → `## [x.y.z]` に変更して PR 作成 → マージ → 自動でタグ + GitHub Release 作成
+
+### バージョン更新基準（Semantic Versioning）
+
+| 変更内容 | バージョン | 例 |
+|---------|-----------|---|
+| 破壊的変更・大規模リリース | MAJOR | 1.0.0 → 2.0.0 |
+| 新機能追加 | MINOR | 1.0.0 → 1.1.0 |
+| バグ修正・小改善・ドキュメント更新 | PATCH | 1.0.0 → 1.0.1 |
+
+## 理由
+
+- 更新忘れをなくす（GitHub Actions タブへの手動アクセス不要）
+- リリース粒度を人間がコントロール（毎 merge ではなく CHANGELOG 変更時のみ）
+- 既存の CHANGELOG 更新ルール（CLAUDE.md）と自然に統合される
+
+## 対象リポジトリ
+
+dhc4mens 配下の全リポジトリに統一適用:
+daihou-corporate-site / daihou-gbp / daihou-sre / CloudLogAI / portfolio


### PR DESCRIPTION
## Summary

- `release.yml` を新規追加（CHANGELOG バージョン検知の自動リリーストリガー）
- main にマージするだけではリリースされない（`## [Unreleased]` のまま）
- `## [Unreleased]` → `## [x.y.z]` に変更して main にマージした時点でタグ + GitHub Release が自動作成
- ADR-001 を追加（意思決定の記録）

全5リポジトリへの統一展開の一環。