### PR TITLE
chore: actions/checkout を @v6 に更新（Node.js 20 deprecation 対応）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
   auto-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## 変更内容

`actions/checkout@v4`（Node.js 20 ベース）を `@v6`（Node.js 24 対応）へ更新。

対象: `release.yml`

## 背景

2026-06-02 から Node.js 24 がデフォルト化、2026-09-16 に Node.js 20 が削除される。

Closes #18